### PR TITLE
GlobalAcceptMessagesFlag feature

### DIFF
--- a/src/RSL/ManagedSrc/Lib/ManagedRSLib.cpp
+++ b/src/RSL/ManagedSrc/Lib/ManagedRSLib.cpp
@@ -1293,6 +1293,11 @@ ManagedRSLStats^ ManagedRSLStateMachine::GetStatisticsSnapshot()
     return result;
 }
 
+void ManagedRSLStateMachine::SetAcceptMessages(bool acceptMessages)
+{
+    m_oMRSLMachine->SetAcceptMessages(acceptMessages);
+}
+
 System::UInt64 ManagedRSLUtils::CalculateChecksum(array<System::Byte>^ data)
 {
     unsigned char* blob = new unsigned char[data->Length];

--- a/src/RSL/ManagedSrc/Lib/ManagedRSLib.h
+++ b/src/RSL/ManagedSrc/Lib/ManagedRSLib.h
@@ -308,6 +308,11 @@ namespace ManagedRSLib
                 Marshal::FreeHGlobal(pStr);
             }
         }
+
+        property bool UseGlobalAcceptMessagesFlag {
+            bool get() { return m_configParam->m_useGlobalAcceptMessagesFlag; }
+            void set(bool value) { m_configParam->m_useGlobalAcceptMessagesFlag = value; }
+        }
     };
 
     public ref class ManagedReplicaHealth
@@ -873,6 +878,8 @@ namespace ManagedRSLib
         }
 
         ManagedRSLStats^ GetStatisticsSnapshot();
+
+        void SetAcceptMessages(bool acceptMessages);
 
         private:
 

--- a/src/RSL/src/legislator.h
+++ b/src/RSL/src/legislator.h
@@ -577,6 +577,8 @@ namespace RSLibImpl
         void RelinquishPrimary();
         bool IsInStableState();
 
+        void SetAcceptMessages(bool acceptMessages);
+
     private:
 
         static Message *UnMarshalMessage(IMarshalMemoryManager *memory);
@@ -869,6 +871,8 @@ namespace RSLibImpl
         CRITSEC m_statsLock;
 
         friend class ExecuteQueue;
+
+        bool m_acceptMessages;
     };
 
     class LegislatorArgWrapper

--- a/src/RSL/src/rsl.cpp
+++ b/src/RSL/src/rsl.cpp
@@ -952,6 +952,12 @@ RSLStateMachine::Resume()
     m_legislator->Resume();
 }
 
+void
+RSLStateMachine::SetAcceptMessages(bool acceptMessages)
+{
+    return m_legislator->SetAcceptMessages(acceptMessages);
+}
+
 //////////////////////
 // MemberSet
 //////////////////////
@@ -1371,6 +1377,7 @@ RSLConfigParam::RSLConfigParam()
     m_workingDir[0] = '\0';
     m_addMemberIdToWorkingDir = true;
     m_cancelDiskIo = true;
+    m_useGlobalAcceptMessagesFlag = false;
 };
 
 RSLNodeCollection::RSLNodeCollection() :

--- a/src/RSL/src/rslconfig.cpp
+++ b/src/RSL/src/rslconfig.cpp
@@ -124,6 +124,7 @@ ConfigParam::Init(RSLConfigParam *param)
     }
 
     m_cancelDiskIo = param->m_cancelDiskIo;
+    m_useGlobalAcceptMessagesFlag = param->m_useGlobalAcceptMessagesFlag;
 
     return true;
 }
@@ -395,3 +396,9 @@ RSLConfig::CancelDiskIo()
     return m_cfg->m_cancelDiskIo;
 }
 
+bool
+RSLConfig::UseGlobalAcceptMessagesFlag()
+{
+    AutoCriticalSection lock(&m_lock);
+    return m_cfg->m_useGlobalAcceptMessagesFlag;
+}

--- a/src/RSL/src/rslconfig.h
+++ b/src/RSL/src/rslconfig.h
@@ -51,6 +51,8 @@ namespace RSLibImpl
         char   m_workingDir[MAX_PATH+1];
         bool m_addMemberIdToWorkingDir;
         bool m_cancelDiskIo;
+
+        bool m_useGlobalAcceptMessagesFlag;
     };
     
     class RSLConfig
@@ -101,6 +103,8 @@ namespace RSLibImpl
         bool AddMemberIdToWorkingDir();
         void ChangeElectionDelay(Int64 delayInSecs);
         bool CancelDiskIo();
+
+        bool UseGlobalAcceptMessagesFlag();
 
         CRITSEC m_lock;
         ConfigParam *m_cfg;

--- a/src/inc/RSL_changelog.md
+++ b/src/inc/RSL_changelog.md
@@ -1,3 +1,14 @@
+## version 1.2.29.0: GlobalAcceptMessagesFlag feature
+
+By default in RSL the thread which participates in message correspondence and vote acceptance will call AcceptMessageFromReplica in the state machine implementation for every vote and prepare message. One side-effect of this is that when using managed state machine implementations this can cause the vote acceptance thread to become blocked due to garbage collection.
+
+This version adds a GlobalAcceptMessagesFlag feature which allows a state machine to decide whether or not to accept votes based on a global flag (settable by the state machine) instead of calling into AcceptMessageFromReplica. When using this feature the message correspondence/vote acceptance
+thread no longer calls into the state machine which ensures these critical RSL functions continue to work even if the state machine is blocked due to garbage collection.
+
+### How to consume it?
+
+This is an opt-in feature. When initializing RSL, the application will need to set UseGlobalAcceptMessagesFlag to true in the RSL configuration parameters. By default RSL will accept all messages. The state machine can call into SetAcceptMessages any time after initialization to enable or disable accepting of messages.
+
 ## version 1.2.0.0: VotePayload feature
 
 This change allows the secondaries to indicate a small payload (64bits) on each vote they accept. This is a very low footprint and high resolution channel from secondaries to the primary that allows the application at the secondaries to communicate the application at the primary aside with their health.

--- a/src/inc/rsl.h
+++ b/src/inc/rsl.h
@@ -496,6 +496,9 @@ namespace RSLib
 
         // Call CancelIoEx to attempt to cancel unwanted disk IO before waiting for its completion.
         bool m_cancelDiskIo;
+
+        // Use global accept messages flag set by SetAcceptMessages rather than calling AcceptMessageFromReplica 
+        bool m_useGlobalAcceptMessagesFlag;
     };
 
     // Filled in by GetStatisticsSnapshot. Returns incremental statistics
@@ -1051,6 +1054,8 @@ namespace RSLib
         * m_cbSizeOfThisStruct (used as a versioning mechanism by the method).
         */
         void GetStatisticsSnapshot(RSLStats * pStats);
+
+        void SetAcceptMessages(bool acceptMessages);
 
         /* These methods are defined only for testing purpose */
         void Pause();


### PR DESCRIPTION
RSL calls AcceptMessageFromReplica in the MainLoop which can cause MainLoop to become blocked for managed state machine implementations if garbage collection occurs. This new opt-in feature provides for setting a global flag for accepting/rejecting messages instead of calling into the state machine for every message. Blocking of MainLoop is undesirable as it can cause to not have enough quroum for voting if it gets blocked when healthy replica count is low. For back-compat this feature is disabled by default.